### PR TITLE
Support custom commands

### DIFF
--- a/eb_ssm/eb_ssm.py
+++ b/eb_ssm/eb_ssm.py
@@ -33,7 +33,7 @@ class SSMWrapper:
 
         self.command = args.command or DEFAULT_COMMAND
 
-        self.non_interactive = args.non_interactive == 'True'
+        self.instance_number = args.number
 
 
     def _parse_args(self):
@@ -60,9 +60,9 @@ class SSMWrapper:
             help="command to execute",
         )
         parser.add_argument(
-            "-n", "--non-interactive",
-            default=False,
-            help="Do not ask any questions, minimize output",
+            "-n", "--number",
+            default=None,
+            help="Specify the instance to connect to by number.",
         )
         return parser.parse_args()
 
@@ -94,8 +94,11 @@ class SSMWrapper:
             sys.exit()
 
         instances = get_instance_ids(self.environment_name)
-        if len(instances) == 1 or self.non_interactive is True:
-            instance = instances[0]
+        if len(instances) == 1:
+          self.instance_number = 0
+
+        if self.instance_number is not None:
+            instance = instances[int(self.instance_number)]
         else:
             io.echo()
             io.echo('Select an instance to ssh into')

--- a/eb_ssm/eb_ssm.py
+++ b/eb_ssm/eb_ssm.py
@@ -11,6 +11,7 @@ from ebcli.operations.commonops import (get_current_branch_environment, get_defa
     get_default_region, get_instance_ids)
 
 LOG = minimal_logger(__name__)
+DEFAULT_COMMAND="bash -l"
 
 
 class SSMWrapper:
@@ -30,7 +31,7 @@ class SSMWrapper:
             "Please specify a specific region in the command or eb configuration.",
         )
 
-        self.command = args.command or "bash -l"
+        self.command = args.command or DEFAULT_COMMAND
 
         self.non_interactive = args.non_interactive == 'True'
 

--- a/eb_ssm/eb_ssm.py
+++ b/eb_ssm/eb_ssm.py
@@ -110,23 +110,7 @@ class SSMWrapper:
         ]
         cmd = " ".join(params)
 
-        # Filter the output of os.system(cmd to remove strange output from Session Manager in non_interactive mode.
-        # The output might begin with:
-        #
-        # Starting session with SessionId: [id]
-        #
-        # and end with:
-        # Exiting session with sessionId:  [id].
-        # @see https://github.com/aws/session-manager-plugin/pull/20
-        # @see https://github.com/aws/amazon-ssm-agent/issues/358
-        if self.non_interactive is True:
-            # A strange workaround until we have the PRs above.
-            output = os.popen(cmd).read()
-            output = output.splitlines()
-            output = output[2:-4]
-            print("\n".join(output))
-        else:
-            os.system(cmd)
+        os.system(cmd)
 
 
 def main():


### PR DESCRIPTION
This allows non-interactive usage like this:

```bash
python3 eb_ssm.py  client-qa --command="drush uli" --non-interactive=True
```